### PR TITLE
fix quote of gpus when launch local

### DIFF
--- a/cosmos_curate/client/local_cli/launch_local.py
+++ b/cosmos_curate/client/local_cli/launch_local.py
@@ -289,7 +289,7 @@ def _launch_in_docker_container(opts: LaunchDocker) -> None:
     is_model_cli = "model_cli" in opts.command
     is_postgres_cli = "postgres_cli" in opts.command
 
-    gpus_string = f"'\"device={opts.gpus}\"'" if opts.gpus else "all"
+    gpus_string = f"\"device={opts.gpus}\"" if opts.gpus else "all"
 
     user_strings = ["-u", f"{os.getuid()}:{os.getgid()}"] if is_model_cli else []
     interactive_strings = ["-i"] if is_postgres_cli else []


### PR DESCRIPTION
## Description
When running `cosmos-curate local launch` with the `--gpus` flag (e.g., `--gpus 0,1,2,3`), the command fails to start the Docker container due to an invalid argument format passed to the underlying `docker run` command. The command is:

```bash
cosmos-curate local launch \
        --image-name $IMAGE_CONTAINER_NAME --image-tag $IMAGE_CONTAINER_TAG \
        --curator-path ${WORKDIR}/cosmos-curate \
        --gpus 0,1,2,3 \
        -- pixi run python -m cosmos_curate.pipelines.video.run_pipeline shard \
        --input-clip-path /config/output_clips\
        --output-dataset-path /config/output_shard_videos \
        --annotation-version v0 2>&1 | tee shard.log
```
Using --gpus '0,1,2,3' or --gpus "0,1,2,3" produces the same error, as shown below:
```
cosmos-curate# cosmos-curate local launch         --image-name $IMAGE_CONTAINER_NAME --image-tag $IMAGE_CONTAINER_TAG         --curator-path ${WORKDIR}/cosmos-curate         --gpus 0,1,2,3         -- pixi run python -m cosmos_curate.pipelines.video.run_pipeline shard         --input-clip-path /config/output_clips        --output-dataset-path /config/output_shard_videos         --annotation-version v0 2>&1 | tee shard.log
2025-12-11 10:37:12.568 | WARNING  | cosmos_curate.client.local_cli.launch_local:_get_s3_creds_mount_strings:170 - No AWS creds file found at /root/.aws/credentials; S3 operations will not work
2025-12-11 10:37:12.569 | INFO     | cosmos_curate.client.local_cli.launch_local:_pause_for_warnings:157 - Pausing for 5 seconds to show above warnings
2025-12-11 10:37:17.574 | INFO     | cosmos_curate.client.local_cli.launch_local:_launch_in_docker_container:333 - Docker command:
docker run --rm --gpus='"device=0,1,2,3"' --device=/dev/dri:/dev/dri --shm-size=604.55gb --network=host --cap-add=SYS_ADMIN -e COSMOS_CURATOR_LOCAL_DOCKER_JOB=1 -e NVCF_REQUEST_STATUS=false -v /home/user/cosmos-curate/COSMOS_CURATE_LOCAL_WORKSPACE/cosmos_curate_local_workspace:/config -v /home/user/cosmos-curate/cosmos_curate:/opt/cosmos-curate/cosmos_curate -v /home/user/cosmos-curate/tests/cosmos_curate:/opt/cosmos-curate/tests/cosmos_curate -v /root/.config/cosmos_curate/config.yaml:/cosmos_curate/config/cosmos_curate.yaml -t **/cosmos-curate:1.1.8 bash -c "pixi run python -m cosmos_curate.pipelines.video.run_pipeline shard --input-clip-path /config/output_clips --output-dataset-path /config/output_shard_videos --annotation-version v0"
invalid argument "'\"device=0,1,2,3\"'" for "--gpus" flag: parse error on line 1, column 2: bare " in non-quoted-field

Usage:  docker run [OPTIONS] IMAGE [COMMAND] [ARG...]

Run 'docker run --help' for more information
2025-12-11 10:37:17.611 | ERROR    | cosmos_curate.client.local_cli.launch_local:_launch_in_docker_container:342 - Failed to run command via docker
```

Upon inspection of cosmos_curate/client/local_cli/launch_local.py, I found that the gpus_string variable was being double-quoted incorrectly. The original code generated a string like: --gpus='"device=0,1,2,3"', which Docker cannot parse correctly.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/nvidia-cosmos/cosmos-curate/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
